### PR TITLE
feat: Add bun installation script and fix hardcoded paths

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -110,4 +110,14 @@ eval "$(starship init zsh)"
 export DYLD_LIBRARY_PATH="$HOME/.local/lib:$DYLD_LIBRARY_PATH"
 
 # opencode
-export PATH=/Users/letusfly85/.opencode/bin:$PATH
+export PATH="$HOME/.opencode/bin:$PATH"
+
+# bun completions
+[ -s "$HOME/.bun/_bun" ] && source "$HOME/.bun/_bun"
+
+# bun
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
+# claude-mem (memory service for Claude Code)
+alias claude-mem="$BUN_INSTALL/bin/bun $HOME/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,14 @@ sudo ln -s $PWD/.powerline-shell.json $HOME/.powerline-shell.json
 - MeCab（形態素解析）
 - Starship プロンプト
 
+### bun のインストール
+
+```bash
+./install-bun.sh
+```
+
+bun（JavaScript/TypeScript ランタイム）がインストールされます。
+
 ## アーキテクチャ
 
 ### 環境管理
@@ -86,12 +94,14 @@ sudo ln -s $PWD/.powerline-shell.json $HOME/.powerline-shell.json
 - `/opt/homebrew/opt/openjdk@17/bin`: OpenJDK 17
 - `$HOME/.cargo/bin`: Rust ツール
 - `$HOME/.local/bin`: Poetry など Python ツール
+- `$HOME/.bun/bin`: bun ランタイム
 
 ## 対応言語とツール
 
 - **Rust**: cargo、各種 Rust クレート
 - **Python**: pyenv、poetry
 - **Node.js**: nodenv
+- **JavaScript/TypeScript**: bun
 - **Java**: jenv、SDKMAN
 - **Scala**: Scala CLI
 - **Shell**: shellcheck、shfmt

--- a/install-bun.sh
+++ b/install-bun.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Install bun (JavaScript runtime & toolkit)
+# https://bun.sh/
+
+set -e
+
+echo "Installing bun..."
+
+# Check if bun is already installed
+if command -v bun &> /dev/null; then
+    echo "bun is already installed: $(bun --version)"
+    echo "Upgrading to latest version..."
+    bun upgrade
+else
+    # Install bun using official installer
+    curl -fsSL https://bun.sh/install | bash
+fi
+
+echo "bun installation completed!"
+echo "Please restart your shell or run: source ~/.zshrc"


### PR DESCRIPTION
## Summary
- Add `install-bun.sh` script for easy bun runtime installation
- Replace hardcoded `/Users/letusfly85` paths with `$HOME` variables in `.zshrc` for portability
- Add bun completions, PATH configuration, and claude-mem alias for Claude Code memory service
- Update `CLAUDE.md` documentation with bun installation instructions and path info

## Changes
- `.zshrc`: Fixed environment-dependent paths and added bun/claude-mem configuration
- `install-bun.sh`: New installation script for bun runtime
- `CLAUDE.md`: Added bun documentation

## Test plan
- [ ] Run `./install-bun.sh` to verify bun installation
- [ ] Source `.zshrc` and verify bun commands work
- [ ] Verify `claude-mem` alias works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)