### PR TITLE
feat: Add Entire CLI installation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ sudo ln -s $PWD/.powerline-shell.json $HOME/.powerline-shell.json
 - Shell 開発ツール（shellcheck、shfmt）
 - MeCab（形態素解析）
 - Starship プロンプト
+- Entire CLI（AIコーディングセッション管理）
 
 ### bun のインストール
 
@@ -106,3 +107,4 @@ bun（JavaScript/TypeScript ランタイム）がインストールされます�
 - **Scala**: Scala CLI
 - **Shell**: shellcheck、shfmt
 - **Infrastructure**: AWS CLI、kubectl、helm、terraform
+- **AI Tools**: Entire CLI（セッション管理）

--- a/install-libraries.sh
+++ b/install-libraries.sh
@@ -33,3 +33,7 @@ brew install mecab-ipadic
 
 # starship
 brew install starship
+
+# Entire CLI (AI coding session management)
+brew tap entireio/tap
+brew install entireio/tap/entire


### PR DESCRIPTION
## Summary
- `install-libraries.sh` に Entire CLI（AIコーディングセッション管理ツール）のインストール手順を追加
- `CLAUDE.md` のドキュメントを更新し、Entire CLI の情報を追記

## 変更内容
- `brew tap entireio/tap` と `brew install entireio/tap/entire` を `install-libraries.sh` に追加
- CLAUDE.md の外部ライブラリ一覧と対応ツール一覧に Entire CLI を追加

## Test plan
- [x] `brew tap entireio/tap && brew install entireio/tap/entire` で正常にインストールされることを確認済み
- [x] `entire version` でバージョン確認済み (Entire CLI 0.4.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)