### PR TITLE
feat: Add Google Cloud SDK path and completion to .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -119,5 +119,9 @@ export PATH="$HOME/.opencode/bin:$PATH"
 export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
+# Google Cloud SDK
+source "/opt/homebrew/share/google-cloud-sdk/path.zsh.inc"
+source "/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc"
+
 # claude-mem (memory service for Claude Code)
 alias claude-mem="$BUN_INSTALL/bin/bun $HOME/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs"


### PR DESCRIPTION
## Summary
- `.zshrc` に Google Cloud SDK のパス設定とZsh補完を追加

## 変更内容
- `source "/opt/homebrew/share/google-cloud-sdk/path.zsh.inc"` でパス設定
- `source "/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc"` でシェル補完

## Test plan
- [x] Google Cloud SDK コマンドが利用可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)