### PR TITLE
feat: Track .entire/ and .claude/ settings for Entire CLI integration

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,84 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-task"
+          }
+        ]
+      },
+      {
+        "matcher": "TodoWrite",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code post-todo"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code pre-task"
+          }
+        ]
+      }
+    ],
+    "SessionEnd": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-end"
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code session-start"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code stop"
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "entire hooks claude-code user-prompt-submit"
+          }
+        ]
+      }
+    ]
+  },
+  "permissions": {
+    "deny": [
+      "Read(./.entire/metadata/**)"
+    ]
+  }
+}

--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,0 +1,4 @@
+tmp/
+settings.local.json
+metadata/
+logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,0 +1,4 @@
+{
+  "strategy": "manual-commit",
+  "enabled": true
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-.entire/
-.claude/
+# .entire/ - managed by .entire/.gitignore (excludes tmp/, settings.local.json, metadata/, logs/)
+# .claude/ - settings.local.json is excluded below
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- `.entire/settings.json` と `.claude/settings.json` をバージョン管理対象に変更
- [Entire CLI ドキュメント](https://docs.entire.io/cli/configuration)の推奨に従い、プロジェクト設定ファイルをコミット対象にする
- ローカル設定（`settings.local.json`）やログ・一時ファイルは引き続き除外

## 変更内容
- `.gitignore`: `.entire/` と `.claude/` のブランケット除外を解除し、`.claude/settings.local.json` のみ除外に変更
- `.entire/.gitignore`: `tmp/`, `settings.local.json`, `metadata/`, `logs/` を除外（既存、新規追跡）
- `.entire/settings.json`: プロジェクト設定（`strategy: manual-commit`）
- `.claude/settings.json`: Entire CLI hooks 連携設定

## 確認事項
- `.entire/settings.json` はドキュメントでコミット推奨と明記されている
- `.claude/settings.json` は Entire CLI の Claude Code hooks 設定で、秘密情報を含まない
- `.entire/settings.local.json` と `.claude/settings.local.json` はコミット対象外

## Test plan
- [ ] `git status` でローカル設定ファイルが追跡されていないことを確認
- [ ] Entire CLI が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)