### PR TITLE
chore: Clean up tmux.conf and remove obsolete settings

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -4,14 +4,11 @@ set-option -g prefix C-y
 bind C-y send-prefix
 
 #split pane
-bind h split-window -h # vertical
-bind v split-window -v # horizon
-
-#TODO
-set -g status on
+bind h split-window -h
+bind v split-window -v
 
 #color
-set -g default-terminal "screen-256color"
+set -g default-terminal "tmux-256color"
 
 #scroll mouse
 set-option -g mouse on
@@ -24,18 +21,6 @@ bind -r > resize-pane -R
 
 #copy mode to vi
 set-window-option -g mode-keys vi
-#unbind Space
-#unbind Return
 bind-key    -T copy-mode-vi v     send-keys -X begin-selection
-bind-key    -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-bind-key    -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "reattach-to-user-namespace pbcopy"
-
-#TODO
-#set-option -g default-command "reattach-to-user-namespace -l bash"
-#set-option -g default-command ""
-
-# https://github.com/idkazuma/dotfiles/blob/master/.tmux.conf
-# if-shell 'test "$(uname)" = "Darwin"' 'set-option -g default-command "reattach-to-user-namespace -l bash"'
-
-bind-key C-c run "tmux save-buffer - | xcopy -i"
-bind-key C-v run "xcopy -o | tmux load-buffer - && tmux paste-buffer"
+bind-key    -T copy-mode-vi y     send-keys -X copy-pipe-and-cancel "pbcopy"
+bind-key    -T copy-mode-vi Enter send-keys -X copy-pipe-and-cancel "pbcopy"


### PR DESCRIPTION
## Summary
- `reattach-to-user-namespace` を削除し、`pbcopy` を直接使用（macOS Sierra 以降では不要）
- 未使用の `xcopy` バインドを削除
- `default-terminal` を `screen-256color` から `tmux-256color` に変更
- デフォルト値である `status on` を削除
- split-window バインドの誤ったコメントを削除
- コメントアウトされた不要なコードを削除

## Test plan
- [ ] tmux を再起動して設定が正しく読み込まれることを確認
- [ ] `C-y` → `h` / `v` でペーン分割が動作することを確認
- [ ] コピーモードで `pbcopy` が正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)