### PR TITLE
fix: wezterm の火星背景画像パスを環境変数ベースに修正

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -7,7 +7,7 @@ local scheme = wezterm.get_builtin_color_schemes()['Gruvbox Light']
 config = {
   background = {
     {
-	source = { File = "/Users/letusfly85/work/wonder-soft/dotfiles/mars.png" },
+	source = { File = os.getenv("HOME") .. "/work/letusfly85/dotfiles/mars.png" },
         attachment = "Fixed", -- 画像を固定位置に配置（ウィンドウサイズに応じて見える範囲が変わる）
         opacity = 0.55, -- 透明度
         vertical_align = "Middle", -- 垂直方向の画像位置


### PR DESCRIPTION
## 概要
wezterm.lua の火星背景画像パスをハードコードされた絶対パスから環境変数ベースの動的なパスに修正しました。

## 変更内容
- `/Users/letusfly85/work/wonder-soft/dotfiles/mars.png` → `os.getenv("HOME") .. "/work/letusfly85/dotfiles/mars.png"`

## 変更理由
- ハードコードされたパスが古いユーザー名とディレクトリを指していたため、背景画像が読み込まれない問題がありました
- 環境変数を使用することで、ユーザー名が変わっても動作するようになります

## 影響範囲
- wezterm.lua の背景画像設定のみ
- 再起動後に火星の背景画像が正しく表示されるようになります

🤖 Generated with [Claude Code](https://claude.com/claude-code)