### PR TITLE
feat: zshrc プロンプトに時間帯カラーテーマ・キラッと効果・リモート差分表示を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -141,6 +141,13 @@ add-zsh-hook precmd _prompt_precmd
 setopt PROMPT_SUBST
 PROMPT='${_PROMPT_DIR}${vcs_info_msg_0_} $ '
 
+# キラキラアニメーション: 1秒ごとにスパークル位置を更新して再描画
+TMOUT=1
+TRAPALRM() {
+  _gradient_dir
+  zle reset-prompt 2>/dev/null
+}
+
 # To Enable Ctrl+a, Ctrl+e
 bindkey -e
 

--- a/.zshrc
+++ b/.zshrc
@@ -33,9 +33,9 @@ _prompt_time_hue() {
 # 初回の色相設定
 _prompt_time_hue
 
-# HSL の色相を truecolor エスケープ用 R;G;B に変換
-_hue2rgb_hsl() {
-  local -F h=$1 s=$2 l=$3
+# HSL の色相を truecolor エスケープ用 R;G;B に変換（S=70%, L=65% 固定）
+_hue2rgb() {
+  local -F h=$1 s=0.70 l=0.65
   local -F c=$(( (1.0 - fabs(2.0 * l - 1.0)) * s ))
   local -F hp=$(( h / 60.0 ))
   local -F x=$(( c * (1.0 - fabs(fmod(hp, 2.0) - 1.0)) ))
@@ -51,34 +51,16 @@ _hue2rgb_hsl() {
   REPLY="$(( int((r+m)*255) ));$(( int((g+m)*255) ));$(( int((b+m)*255) ))"
 }
 
-# 通常のグラデーション色（S=70%, L=65%）
-_hue2rgb() { _hue2rgb_hsl $1 0.70 0.65 }
-
-# キラッとグロー用（S=25%, L=88%: 白寄りの明るい色）
-_hue2rgb_glow() { _hue2rgb_hsl $1 0.25 0.88 }
-
-# ディレクトリ文字列をグラデーションで着色（キラッと効果付き）
+# ディレクトリ文字列をグラデーションで着色
 _gradient_dir() {
   local dir="${(%):-%~}"
   local -i len=${#dir}
   local -F step=$(( len > 1 ? 50.0 / len : 0 ))
   local esc=$'\e'
-  # キラッと効果: 約30%の確率で3文字幅のグロー（中心=ゴールド, 両脇=明るく）
-  local -i sparkle_pos=0
-  (( RANDOM % 100 < 30 && len >= 3 )) && sparkle_pos=$(( RANDOM % (len - 2) + 2 ))
   _PROMPT_DIR=""
   for (( i = 1; i <= len; i++ )); do
-    if (( sparkle_pos > 0 && i == sparkle_pos )); then
-      # 中心: bold + 鮮やかなゴールド
-      _PROMPT_DIR+="%{${esc}[1;38;2;255;215;60m%}${dir[$i]}%{${esc}[22m%}"
-    elif (( sparkle_pos > 0 && (i == sparkle_pos - 1 || i == sparkle_pos + 1) )); then
-      # 両脇: グロー（白寄りの明るい色）
-      _hue2rgb_glow $(( fmod(_PROMPT_HUE + (i-1) * step, 360.0) ))
-      _PROMPT_DIR+="%{${esc}[38;2;${REPLY}m%}${dir[$i]}"
-    else
-      _hue2rgb $(( fmod(_PROMPT_HUE + (i-1) * step, 360.0) ))
-      _PROMPT_DIR+="%{${esc}[38;2;${REPLY}m%}${dir[$i]}"
-    fi
+    _hue2rgb $(( fmod(_PROMPT_HUE + (i-1) * step, 360.0) ))
+    _PROMPT_DIR+="%{${esc}[38;2;${REPLY}m%}${dir[$i]}"
   done
   _PROMPT_DIR+="%f"
 }
@@ -140,13 +122,6 @@ add-zsh-hook precmd _prompt_precmd
 
 setopt PROMPT_SUBST
 PROMPT='${_PROMPT_DIR}${vcs_info_msg_0_} $ '
-
-# キラキラアニメーション: 1秒ごとにスパークル位置を更新して再描画
-TMOUT=1
-TRAPALRM() {
-  _gradient_dir
-  zle reset-prompt 2>/dev/null
-}
 
 # To Enable Ctrl+a, Ctrl+e
 bindkey -e

--- a/.zshrc
+++ b/.zshrc
@@ -5,10 +5,33 @@ export SAVEHIST=100000
 
 # プロンプト設定（グラデーション付きディレクトリ + git ブランチ/ステータス）
 zmodload zsh/mathfunc
+zmodload zsh/datetime
 autoload -Uz vcs_info add-zsh-hook
 
-# タブごとにランダムな基準色を割り当て（0-360 の色相）
-_PROMPT_HUE=$((RANDOM % 360))
+# 時間帯ベースの色相範囲（JST）
+# 朝(5-9): 暖かい朝焼け, 昼(9-13): 明るい黄緑,
+# 午後(13-17): 爽やかシアン, 夕方(17-20): 夕焼けマゼンタ, 夜(20-5): 深い青紫
+_prompt_time_hue() {
+  local hour_str
+  TZ=Asia/Tokyo strftime -s hour_str '%H' $EPOCHSECONDS
+  local -i hour=$(( 10#$hour_str ))
+  local -i hue_min hue_max
+  if (( hour >= 5 && hour < 9 )); then
+    hue_min=15; hue_max=55       # 朝焼けのオレンジ〜ピンク
+  elif (( hour >= 9 && hour < 13 )); then
+    hue_min=55; hue_max=140      # 陽光の黄色〜緑
+  elif (( hour >= 13 && hour < 17 )); then
+    hue_min=140; hue_max=210     # 午後の緑〜シアン
+  elif (( hour >= 17 && hour < 20 )); then
+    hue_min=300; hue_max=360     # 夕焼けの赤〜マゼンタ
+  else
+    hue_min=220; hue_max=300     # 夜空の青〜紫
+  fi
+  _PROMPT_HUE=$(( hue_min + RANDOM % (hue_max - hue_min + 1) ))
+}
+
+# 初回の色相設定
+_prompt_time_hue
 
 # HSL の色相を truecolor エスケープ用 R;G;B に変換（S=70%, L=65% 固定）
 _hue2rgb() {
@@ -28,16 +51,23 @@ _hue2rgb() {
   REPLY="$(( int((r+m)*255) ));$(( int((g+m)*255) ));$(( int((b+m)*255) ))"
 }
 
-# ディレクトリ文字列をグラデーションで着色
+# ディレクトリ文字列をグラデーションで着色（キラッと効果付き）
 _gradient_dir() {
   local dir="${(%):-%~}"
   local -i len=${#dir}
   local -F step=$(( len > 1 ? 50.0 / len : 0 ))
   local esc=$'\e'
+  # キラッと効果: 約30%の確率で1文字だけ高輝度に光る
+  local -i sparkle_pos=-1
+  (( RANDOM % 100 < 30 )) && sparkle_pos=$(( RANDOM % len + 1 ))
   _PROMPT_DIR=""
   for (( i = 1; i <= len; i++ )); do
-    _hue2rgb $(( fmod(_PROMPT_HUE + (i-1) * step, 360.0) ))
-    _PROMPT_DIR+="%{${esc}[38;2;${REPLY}m%}${dir[$i]}"
+    if (( i == sparkle_pos )); then
+      _PROMPT_DIR+="%{${esc}[1;38;2;255;255;230m%}${dir[$i]}%{${esc}[22m%}"
+    else
+      _hue2rgb $(( fmod(_PROMPT_HUE + (i-1) * step, 360.0) ))
+      _PROMPT_DIR+="%{${esc}[38;2;${REPLY}m%}${dir[$i]}"
+    fi
   done
   _PROMPT_DIR+="%f"
 }
@@ -51,7 +81,7 @@ zstyle ':vcs_info:git:*' formats ' %F{cyan}(%b%c%u%m%F{cyan})%f'
 zstyle ':vcs_info:git:*' actionformats ' %F{cyan}(%b%F{cyan}|%F{red}%a%c%u%m%F{cyan})%f'
 
 # vcs_info hooks: ブランチ色分け + untracked 検出
-zstyle ':vcs_info:git*+set-message:*' hooks git-branch-color git-untracked
+zstyle ':vcs_info:git*+set-message:*' hooks git-branch-color git-untracked git-remote-status
 
 # conventional branch prefix でブランチ名の色を変える
 +vi-git-branch-color() {
@@ -75,11 +105,23 @@ zstyle ':vcs_info:git*+set-message:*' hooks git-branch-color git-untracked
 +vi-git-untracked() {
   if [[ $(command git rev-parse --is-inside-work-tree 2>/dev/null) == 'true' ]] \
      && command git status --porcelain 2>/dev/null | command grep -q '^??'; then
-    hook_com[misc]='%F{red}?'
+    hook_com[misc]+='%F{red}?'
   fi
 }
 
+# リモートブランチとの差分（↑push待ち ↓pull待ち）
++vi-git-remote-status() {
+  local -i ahead behind
+  ahead=$(command git rev-list --count @{upstream}..HEAD 2>/dev/null) || return
+  behind=$(command git rev-list --count HEAD..@{upstream} 2>/dev/null) || return
+  local arrows=""
+  (( ahead > 0 )) && arrows+="%F{green}↑${ahead}"
+  (( behind > 0 )) && arrows+="%F{red}↓${behind}"
+  [[ -n "$arrows" ]] && hook_com[misc]+="${arrows}"
+}
+
 _prompt_precmd() {
+  _prompt_time_hue
   vcs_info
   _gradient_dir
 }


### PR DESCRIPTION
## Summary
- ディレクトリのグラデーション色相をJST時間帯（朝/昼/午後/夕方/夜）に応じて変化させ、各帯域内でランダム選択することで飽きない色味を実現
- `vcs_info` hook で upstream ブランチとの ahead/behind を `↑N`（push待ち）`↓N`（pull待ち）の矢印で表示

## 変更詳細

### 1. 時間帯ベースカラーテーマ
| 時間帯 | JST | 色相範囲 | イメージ |
|--------|-----|---------|---------|
| 朝 | 5-9時 | 15°-55° | 暖かい朝焼けオレンジ〜ピンク |
| 昼 | 9-13時 | 55°-140° | 陽光の黄色〜緑 |
| 午後 | 13-17時 | 140°-210° | 爽やかな緑〜シアン |
| 夕方 | 17-20時 | 300°-360° | 夕焼けの赤〜マゼンタ |
| 夜 | 20-5時 | 220°-300° | 夜空の青〜紫 |

- `zsh/datetime` モジュールで fork なしに現在時刻を取得（`strftime` + `$EPOCHSECONDS`）
- 毎プロンプトで `_prompt_time_hue` を呼び出し、時間帯の範囲内でランダムに色相を選択

### 2. リモートブランチ差分表示
- `+vi-git-remote-status` hook を追加
- `git rev-list --count` で upstream との差分を算出
- `↑N`（緑: push すべきコミット）、`↓N`（赤: pull すべきコミット）をブランチ情報の横に表示
- upstream が設定されていないブランチでは表示しない

### キラキラアニメーションについて
`zle reset-prompt` / ANSI 直接書き込み等の手法を試行したが、以下のターミナルの構造的制約により断念:
- テキスト選択（コピペ）が壊れる（Kitty #7408 等で既知）
- ブランチ名等のプロンプト状態が競合で崩壊する
- Starship / Powerlevel10k / Oh My Posh いずれもアニメーション非対応（同じ理由）

## Test plan
- [x] 新しいターミナルタブを開いてプロンプトが正常に表示されることを確認
- [x] ディレクトリ部分にグラデーションが表示され、時間帯に応じた色味であることを確認
- [x] git リポジトリ内でブランチ名が表示されることを確認
- [ ] ローカルで未 push のコミットがある場合に `↑N` が緑で表示されることを確認
- [ ] リモートに未 pull のコミットがある場合に `↓N` が赤で表示されることを確認
- [ ] upstream のないブランチで矢印が表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)