### PR TITLE
fix: zshrc クロスプラットフォーム対応ガード追加と wezterm マウス操作改善

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -185,7 +185,9 @@ fi
 export PATH=${0:A:h}/bin:$PATH
 
 # direnv
-eval "$(direnv hook zsh)"
+if command -v direnv &>/dev/null; then
+  eval "$(direnv hook zsh)"
+fi
 
 # SSH補完
 function _ssh {
@@ -202,19 +204,26 @@ if [ -d $HOME/.nodenv ]; then
   eval "$(nodenv init -)"
 fi
 
+# wezterm shell integration
+if [ -f /etc/profile.d/wezterm.sh ]; then
+  source /etc/profile.d/wezterm.sh
+fi
+
 # atuin (シェル履歴管理)
 if [ -f $HOME/.cargo/bin/atuin ]; then
   eval "$(atuin init zsh)"
 fi
 
 # パス設定
-export PATH="/usr/local/opt/libpq/bin:$PATH"
-export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"
-export PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH"
+[ -d "/usr/local/opt/libpq/bin" ] && export PATH="/usr/local/opt/libpq/bin:$PATH"
+[ -d "/opt/homebrew/opt/mysql-client/bin" ] && export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"
+[ -d "/opt/homebrew/opt/openjdk@17/bin" ] && export PATH="/opt/homebrew/opt/openjdk@17/bin:$PATH"
 
 # jenv
-export PATH="$HOME/.jenv/bin:$PATH"
-eval "$(jenv init -)"
+if [ -d "$HOME/.jenv" ]; then
+  export PATH="$HOME/.jenv/bin:$PATH"
+  eval "$(jenv init -)"
+fi
 
 
 # SDKMAN
@@ -222,9 +231,16 @@ export SDKMAN_DIR="$HOME/.sdkman"
 [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
 
 # asdf
-. /opt/homebrew/opt/asdf/libexec/asdf.sh
+if [ -f /opt/homebrew/opt/asdf/libexec/asdf.sh ]; then
+  . /opt/homebrew/opt/asdf/libexec/asdf.sh
+elif [ -f "$HOME/.asdf/asdf.sh" ]; then
+  . "$HOME/.asdf/asdf.sh"
+fi
 
-export DYLD_LIBRARY_PATH="$HOME/.local/lib:$DYLD_LIBRARY_PATH"
+# macOS only
+if [[ "$OSTYPE" == darwin* ]]; then
+  export DYLD_LIBRARY_PATH="$HOME/.local/lib:$DYLD_LIBRARY_PATH"
+fi
 
 # opencode
 export PATH="$HOME/.opencode/bin:$PATH"
@@ -237,8 +253,13 @@ export BUN_INSTALL="$HOME/.bun"
 export PATH="$BUN_INSTALL/bin:$PATH"
 
 # Google Cloud SDK
-source "/opt/homebrew/share/google-cloud-sdk/path.zsh.inc"
-source "/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc"
+if [ -f "/opt/homebrew/share/google-cloud-sdk/path.zsh.inc" ]; then
+  source "/opt/homebrew/share/google-cloud-sdk/path.zsh.inc"
+  source "/opt/homebrew/share/google-cloud-sdk/completion.zsh.inc"
+elif [ -f "$HOME/google-cloud-sdk/path.zsh.inc" ]; then
+  source "$HOME/google-cloud-sdk/path.zsh.inc"
+  source "$HOME/google-cloud-sdk/completion.zsh.inc"
+fi
 
 # claude-mem (memory service for Claude Code)
 alias claude-mem="$BUN_INSTALL/bin/bun $HOME/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ sudo ln -s $PWD/.zshrc $HOME/.zshrc
 # tmux
 sudo ln -s $PWD/.tmux.conf $HOME/.tmux.conf
 
+# Wezterm
+ln -s $PWD/wezterm.lua $HOME/.wezterm.lua
+```
+
 ### Rust クレートのインストール
 
 ```bash

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -6,7 +6,14 @@ local scheme = wezterm.get_builtin_color_schemes()['Gruvbox Light']
 
 local act = wezterm.action
 
+-- macOS/Linux 両対応: zsh をデフォルトシェルに
+local zsh_path = '/bin/zsh'
+if wezterm.target_triple:find('apple') then
+  zsh_path = '/bin/zsh'
+end
+
 config = {
+  default_prog = { zsh_path, '-l' },
   background = {
     {
 	source = { File = os.getenv("HOME") .. "/work/letusfly85/dotfiles/mars.png" },
@@ -122,6 +129,7 @@ config = {
 
   -- マウスホイールスクロールを固定行数にしてガクガクを防止
   mouse_bindings = {
+    -- マウスホイールスクロール
     {
       event = { Down = { streak = 1, button = { WheelUp = 1 } } },
       mods = 'NONE',
@@ -133,6 +141,18 @@ config = {
       mods = 'NONE',
       action = act.ScrollByLine(3),
       alt_screen = false,
+    },
+    -- 選択範囲をクリップボードにコピー（左ボタンを離した時）
+    {
+      event = { Up = { streak = 1, button = 'Left' } },
+      mods = 'NONE',
+      action = act.CompleteSelectionOrOpenLinkAtMouseCursor('ClipboardAndPrimarySelection'),
+    },
+    -- 右クリックでクリップボードからペースト
+    {
+      event = { Down = { streak = 1, button = 'Right' } },
+      mods = 'NONE',
+      action = act.PasteFrom('Clipboard'),
     },
   },
 }


### PR DESCRIPTION
## Summary
- zshrc: direnv, jenv, asdf, Google Cloud SDK 等にコマンド/ディレクトリ存在チェックガードを追加し、環境差異によるエラーを防止
- zshrc: wezterm shell integration を追加、DYLD_LIBRARY_PATH を macOS のみに制限
- wezterm: デフォルトシェルに zsh を設定、マウス選択コピー・右クリックペーストを追加
- CLAUDE.md: Wezterm シンボリックリンク手順の欠落を修正

## Test plan
- [ ] macOS で zshrc を読み込みエラーなく起動することを確認
- [ ] Linux で zshrc を読み込みエラーなく起動することを確認
- [ ] wezterm でマウス選択→コピー、右クリック→ペーストが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)