### PR TITLE
fix: wezterm フォントウェイトを Regular に変更

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -120,7 +120,7 @@ config = {
     top = 0,
     bottom = 0,
   },
-  font = wezterm.font('Cica', { weight = 'DemiBold' }),
+  font = wezterm.font('Cica', { weight = 'Regular' }),
 
   -- スクロール性能の改善
   max_fps = 120,


### PR DESCRIPTION
## Summary
- Cica フォントに DemiBold ウェイトが存在せず Linux で正しくマッチしない問題を修正
- `DemiBold` → `Regular` に変更

## Test plan
- [ ] wezterm で Cica Regular フォントが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)