### PR TITLE
fix: 新しいタブのデフォルトディレクトリ設定と OSC 7 修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -204,9 +204,16 @@ if [ -d $HOME/.nodenv ]; then
   eval "$(nodenv init -)"
 fi
 
-# wezterm shell integration
+# wezterm shell integration (OSC 7 でカレントディレクトリをターミナルに通知)
 if [ -f /etc/profile.d/wezterm.sh ]; then
   source /etc/profile.d/wezterm.sh
+elif [ -n "$WEZTERM_EXECUTABLE" ]; then
+  # macOS: wezterm shell integration を直接設定
+  _wezterm_osc7() {
+    printf '\e]7;file://%s%s\e\\' "${HOST}" "${PWD}"
+  }
+  add-zsh-hook chpwd _wezterm_osc7
+  _wezterm_osc7
 fi
 
 # atuin (シェル履歴管理)

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -12,8 +12,13 @@ if wezterm.target_triple:find('apple') then
   zsh_path = '/bin/zsh'
 end
 
+-- デフォルトの作業ディレクトリを設定
+local default_cwd = wezterm.home_dir
+local work_dir = wezterm.home_dir .. '/work'
+
 config = {
   default_prog = { zsh_path, '-l' },
+  default_cwd = work_dir,
   background = {
     {
 	source = { File = os.getenv("HOME") .. "/work/letusfly85/dotfiles/mars.png" },


### PR DESCRIPTION
## Summary
- wezterm の `default_cwd` を `$HOME/work` に設定し、新しいタブ/ウィンドウのデフォルトディレクトリを変更
- macOS 環境で OSC 7 shell integration が機能していなかった問題を修正（`/etc/profile.d/wezterm.sh` は Linux 用パスのため）
- `$WEZTERM_EXECUTABLE` 環境変数で wezterm 内かどうかを判定し、`chpwd` フックで OSC 7 を送信するよう対応

## Test plan
- [x] wezterm で新しいタブを開き、`$HOME/work` がデフォルトディレクトリになることを確認
- [x] タブ内で `cd` 後に新しいタブを開き、作業ディレクトリが引き継がれることを確認
- [x] Linux 環境で既存の `/etc/profile.d/wezterm.sh` が優先されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)