### PR TITLE
feat: wezterm フォントを OS ごとに分岐（macOS は Cica Bold）

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -88,7 +88,6 @@ config = {
     },
   },
 
-  font_size = 20.0,
   use_ime = true,
   window_background_opacity = 0.70,
   macos_window_background_blur = 40,
@@ -125,7 +124,11 @@ config = {
     top = 0,
     bottom = 0,
   },
-  font = wezterm.font('Cica', { weight = 'Regular' }),
+  -- フォント設定: macOS は Cica Bold + 大きめ、Linux は Cica Regular + 小さめ
+  font = wezterm.target_triple:find('apple')
+    and wezterm.font('Cica', { weight = 'Bold' })
+    or wezterm.font('Cica', { weight = 'Regular' }),
+  font_size = wezterm.target_triple:find('apple') and 20.0 or 16.0,
 
   -- スクロール性能の改善
   max_fps = 120,


### PR DESCRIPTION
## Summary
- macOS: Cica **Bold** / 20pt
- Linux: Cica Regular / 16pt
- `wezterm.target_triple` で OS を判定して切り替え

## Test plan
- [ ] macOS で wezterm を再起動し、Cica Bold が適用されていることを確認
- [ ] Linux で wezterm を再起動し、Cica Regular が適用されていることを確認
- [ ] フォントサイズが OS ごとに正しく設定されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)