### PR TITLE
feat: zshrc に nvm セットアップと ~/bin PATH を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -1,4 +1,5 @@
 # 基本設定
+export PATH="$HOME/bin:$PATH"
 export LANG=ja_JP.UTF-8
 export EDITOR=vim
 export SAVEHIST=100000
@@ -270,3 +271,8 @@ fi
 
 # claude-mem (memory service for Claude Code)
 alias claude-mem="$BUN_INSTALL/bin/bun $HOME/.claude/plugins/marketplaces/thedotmack/plugin/scripts/worker-service.cjs"
+
+export NVM_DIR="$HOME/.nvm"
+[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
+[ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+nvm use default --silent > /dev/null 2>&1


### PR DESCRIPTION
## Summary
- `$HOME/bin` を PATH に追加
- nvm (Node Version Manager) の初期化設定を追加（nvm.sh 読み込み、bash_completion、デフォルトバージョンの自動切替）

## Test plan
- [ ] シェル起動時に nvm が正しくロードされることを確認
- [ ] `nvm use default` でデフォルト Node.js バージョンが適用されることを確認
- [ ] `$HOME/bin` 配下のコマンドが PATH で認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)