### PR TITLE
feat: Entire CLI のシェル補完を zshrc に追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -276,3 +276,6 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 nvm use default --silent > /dev/null 2>&1
+
+# Entire CLI shell completion
+autoload -Uz compinit && compinit && source <(entire completion zsh)


### PR DESCRIPTION
## Summary
- Entire CLI（AIコーディングセッション管理ツール）の zsh 補完を追加
- `autoload -Uz compinit && compinit` で補完システムを初期化し、`entire completion zsh` の出力をソース

## Test plan
- [ ] `source ~/.zshrc` でエラーが出ないことを確認
- [ ] `entire` コマンドの後にタブ補完が効くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)