### PR TITLE
feat: SSH接続時にエイリアン宇宙船風テーマを適用

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -122,7 +122,17 @@ _prompt_precmd() {
 add-zsh-hook precmd _prompt_precmd
 
 setopt PROMPT_SUBST
-PROMPT='${_PROMPT_DIR}${vcs_info_msg_0_} $ '
+
+# SSH接続検出: 他の宇宙船に乗り込んだ感を演出
+if [[ -n "$SSH_CONNECTION" ]]; then
+  # SSH先ではプロンプトの色相をエイリアン宇宙船風（青紫〜シアン）に固定
+  _prompt_time_hue() { _PROMPT_HUE=$(( 200 + RANDOM % 80 )); }
+  _prompt_time_hue
+  # ホスト名をネオンシアンで表示 + 宇宙船アイコン
+  PROMPT='%F{51}⟐ %m%f ${_PROMPT_DIR}${vcs_info_msg_0_} %F{51}▸%f '
+else
+  PROMPT='${_PROMPT_DIR}${vcs_info_msg_0_} $ '
+fi
 
 # To Enable Ctrl+a, Ctrl+e
 bindkey -e

--- a/.zshrc
+++ b/.zshrc
@@ -125,7 +125,7 @@ setopt PROMPT_SUBST
 
 # SSH接続検出: 他の宇宙船に乗り込んだ感を演出
 if [[ -n "$SSH_CONNECTION" ]]; then
-  # SSH先ではプロンプトの色相をエイリアン宇宙船風（青紫〜シアン）に固定
+  # SSH先ではプロンプトの色相をエイリアン宇宙船風（青紫〜シアン: 200-280）にランダム変化
   _prompt_time_hue() { _PROMPT_HUE=$(( 200 + RANDOM % 80 )); }
   _prompt_time_hue
   # ホスト名をネオンシアンで表示 + 宇宙船アイコン

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -193,6 +193,57 @@ wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_wid
   }
 end)
 
+-- SSH接続検出: 他の宇宙船に乗り込んだ演出
+-- 現在の火星テーマから、冷たい青紫のエイリアン宇宙船風に切り替え
+wezterm.on('update-status', function(window, pane)
+  local proc = pane:get_foreground_process_name() or ''
+  if proc:find('ssh$') then
+    window:set_config_overrides({
+      -- エイリアン宇宙船の背景グラデーション
+      window_background_gradient = {
+        colors = { '#000010', '#0A0A2E', '#0F1A3A', '#162050', '#1A1A4A' },
+        orientation = 'Vertical',
+        blend = 'LinearRgb',
+      },
+      -- 背景画像のオーバーレイを暗い青紫に
+      background = {
+        {
+          source = { File = os.getenv('HOME') .. '/work/letusfly85/dotfiles/mars.png' },
+          attachment = 'Fixed',
+          opacity = 0.25,
+          vertical_align = 'Middle',
+          horizontal_align = 'Center',
+          horizontal_offset = '0px',
+          repeat_x = 'NoRepeat',
+          repeat_y = 'NoRepeat',
+          height = '100%',
+          -- 青いティントで火星画像を異星感に
+          hsb = { hue = 0.6, saturation = 1.5, brightness = 0.4 },
+        },
+        {
+          source = {
+            Gradient = {
+              colors = { '#000020', '#0A0A3E' },
+              orientation = { Linear = { angle = -50.0 } },
+            },
+          },
+          opacity = 0.55,
+          width = '100%',
+          height = '100%',
+        },
+      },
+      colors = {
+        tab_bar = {
+          inactive_tab_edge = 'none',
+        },
+        scrollbar_thumb = 'rgba(100, 100, 255, 0.35)',
+      },
+    })
+  else
+    window:set_config_overrides({})
+  end
+end)
+
 wezterm.on('bell', function(window, pane)
   window:toast_notification('Claude Code', 'Task completed', nil, 4000)
 end)

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -267,10 +267,15 @@ local function apply_interpolated_theme(window, t)
   local overrides = window:get_config_overrides() or {}
 
   if t <= 0.001 then
-    -- 完全に火星テーマ → テーマ関連キーを削除して元のconfigに戻す
+    -- 完全に火星テーマ → テーマ関連キーのみ削除して元のconfigに戻す
     overrides.window_background_gradient = nil
     overrides.background = nil
-    overrides.colors = nil
+    -- colors は他のキーを保持し、テーマ関連キーのみ削除
+    if overrides.colors then
+      overrides.colors.tab_bar = nil
+      overrides.colors.scrollbar_thumb = nil
+      if not next(overrides.colors) then overrides.colors = nil end
+    end
     window:set_config_overrides(overrides)
     return
   end
@@ -331,10 +336,10 @@ local function apply_interpolated_theme(window, t)
       height = '100%',
     },
   }
-  overrides.colors = {
-    tab_bar = { inactive_tab_edge = 'none' },
-    scrollbar_thumb = sb,
-  }
+  -- colors は既存キーを保持しつつテーマ関連キーのみ更新
+  overrides.colors = overrides.colors or {}
+  overrides.colors.tab_bar = { inactive_tab_edge = 'none' }
+  overrides.colors.scrollbar_thumb = sb
   window:set_config_overrides(overrides)
 end
 

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -248,19 +248,30 @@ local theme_alien = {
   scrollbar    = { 100, 100, 255, 0.35 },
 }
 
--- トランジション状態管理
-local transition_state = {
-  current = 'mars',   -- 現在のテーマ
-  step = 0,           -- 現在のステップ (0 = 完了)
-}
+-- トランジション状態管理（ウィンドウ単位で管理し、複数ウィンドウの干渉を防ぐ）
+local transition_states = {}  -- window_id -> { current, generation }
 local TRANSITION_STEPS = 8
 local TRANSITION_INTERVAL = 0.05  -- 各ステップ間隔（秒） → 合計 ~400ms
 
+local function get_win_state(window)
+  local wid = tostring(window:window_id())
+  if not transition_states[wid] then
+    transition_states[wid] = { current = 'mars', generation = 0 }
+  end
+  return transition_states[wid], wid
+end
+
 -- t (0.0=mars, 1.0=alien) に基づいて中間テーマを適用
+-- 既存の per-window override を保持しつつ、テーマ関連キーのみ更新する
 local function apply_interpolated_theme(window, t)
+  local overrides = window:get_config_overrides() or {}
+
   if t <= 0.001 then
-    -- 完全に火星テーマ → オーバーライド解除で元のconfigに戻す
-    window:set_config_overrides({})
+    -- 完全に火星テーマ → テーマ関連キーを削除して元のconfigに戻す
+    overrides.window_background_gradient = nil
+    overrides.background = nil
+    overrides.colors = nil
+    window:set_config_overrides(overrides)
     return
   end
 
@@ -286,60 +297,63 @@ local function apply_interpolated_theme(window, t)
     math.floor(lerp(from.scrollbar[3], to.scrollbar[3], t)),
     lerp(from.scrollbar[4], to.scrollbar[4], t))
 
-  window:set_config_overrides({
-    window_background_gradient = {
-      colors = grad,
-      orientation = 'Vertical',
-      blend = 'LinearRgb',
-    },
-    background = {
-      {
-        source = { File = mars_img },
-        attachment = 'Fixed',
-        opacity = lerp(from.img_opacity, to.img_opacity, t),
-        vertical_align = 'Middle',
-        horizontal_align = 'Center',
-        horizontal_offset = '0px',
-        repeat_x = 'NoRepeat',
-        repeat_y = 'NoRepeat',
-        height = '100%',
-        hsb = {
-          hue = lerp(from.img_hue, to.img_hue, t),
-          saturation = lerp(from.img_sat, to.img_sat, t),
-          brightness = lerp(from.img_bright, to.img_bright, t),
-        },
-      },
-      {
-        source = {
-          Gradient = {
-            colors = ovr,
-            orientation = { Linear = { angle = -50.0 } },
-          },
-        },
-        opacity = lerp(from.ovr_opacity, to.ovr_opacity, t),
-        width = '100%',
-        height = '100%',
+  overrides.window_background_gradient = {
+    colors = grad,
+    orientation = 'Vertical',
+    blend = 'LinearRgb',
+  }
+  overrides.background = {
+    {
+      source = { File = mars_img },
+      attachment = 'Fixed',
+      opacity = lerp(from.img_opacity, to.img_opacity, t),
+      vertical_align = 'Middle',
+      horizontal_align = 'Center',
+      horizontal_offset = '0px',
+      repeat_x = 'NoRepeat',
+      repeat_y = 'NoRepeat',
+      height = '100%',
+      hsb = {
+        hue = lerp(from.img_hue, to.img_hue, t),
+        saturation = lerp(from.img_sat, to.img_sat, t),
+        brightness = lerp(from.img_bright, to.img_bright, t),
       },
     },
-    colors = {
-      tab_bar = { inactive_tab_edge = 'none' },
-      scrollbar_thumb = sb,
+    {
+      source = {
+        Gradient = {
+          colors = ovr,
+          orientation = { Linear = { angle = -50.0 } },
+        },
+      },
+      opacity = lerp(from.ovr_opacity, to.ovr_opacity, t),
+      width = '100%',
+      height = '100%',
     },
-  })
+  }
+  overrides.colors = {
+    tab_bar = { inactive_tab_edge = 'none' },
+    scrollbar_thumb = sb,
+  }
+  window:set_config_overrides(overrides)
 end
 
--- フェードトランジションを開始
+-- フェードトランジションを開始（世代番号で旧コールバックを無効化）
 local function start_transition(window, target)
-  if transition_state.current == target then return end
-  transition_state.current = target
-  transition_state.step = 1
+  local state = get_win_state(window)
+  if state.current == target then return end
+  state.current = target
+  state.generation = state.generation + 1
+  local my_gen = state.generation
 
+  local step = 1
   local function step_fn()
-    local s = transition_state.step
-    if s > TRANSITION_STEPS then return end
+    -- 世代が変わっていたら旧トランジション → 何もしない
+    if state.generation ~= my_gen then return end
+    if step > TRANSITION_STEPS then return end
 
     -- イーズイン・アウト (smoothstep) で滑らかに
-    local raw_t = s / TRANSITION_STEPS
+    local raw_t = step / TRANSITION_STEPS
     local t = raw_t * raw_t * (3 - 2 * raw_t)
 
     -- mars→alien なら t をそのまま、alien→mars なら反転
@@ -347,8 +361,8 @@ local function start_transition(window, target)
 
     apply_interpolated_theme(window, t)
 
-    transition_state.step = s + 1
-    if s < TRANSITION_STEPS then
+    step = step + 1
+    if step <= TRANSITION_STEPS then
       wezterm.time.call_after(TRANSITION_INTERVAL, step_fn)
     end
   end
@@ -356,6 +370,8 @@ local function start_transition(window, target)
   step_fn()
 end
 
+-- ローカルpane上の前景プロセスが ssh の場合にテーマを切り替える
+-- 注: multiplexer pane や wezterm ssh ドメインでは検出不可
 wezterm.on('update-status', function(window, pane)
   local proc = pane:get_foreground_process_name() or ''
   if proc:find('ssh$') then

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -249,14 +249,15 @@ local theme_alien = {
 }
 
 -- トランジション状態管理（ウィンドウ単位で管理し、複数ウィンドウの干渉を防ぐ）
-local transition_states = {}  -- window_id -> { current, generation }
+-- current_t: 現在の補間位置 (0.0=mars, 1.0=alien) を保持し、途中反転時のジャンプを防ぐ
+local transition_states = {}  -- window_id -> { current, generation, current_t, last_proc }
 local TRANSITION_STEPS = 8
 local TRANSITION_INTERVAL = 0.05  -- 各ステップ間隔（秒） → 合計 ~400ms
 
 local function get_win_state(window)
   local wid = tostring(window:window_id())
   if not transition_states[wid] then
-    transition_states[wid] = { current = 'mars', generation = 0 }
+    transition_states[wid] = { current = 'mars', generation = 0, current_t = 0.0, last_proc = '' }
   end
   return transition_states[wid], wid
 end
@@ -344,12 +345,17 @@ local function apply_interpolated_theme(window, t)
 end
 
 -- フェードトランジションを開始（世代番号で旧コールバックを無効化）
+-- current_t を保持し、途中反転時は現在位置から補間を開始する
 local function start_transition(window, target)
   local state = get_win_state(window)
   if state.current == target then return end
   state.current = target
   state.generation = state.generation + 1
   local my_gen = state.generation
+
+  -- 途中反転対応: 現在の t を起点にする
+  local start_t = state.current_t
+  local end_t = (target == 'alien') and 1.0 or 0.0
 
   local step = 1
   local function step_fn()
@@ -359,11 +365,12 @@ local function start_transition(window, target)
 
     -- イーズイン・アウト (smoothstep) で滑らかに
     local raw_t = step / TRANSITION_STEPS
-    local t = raw_t * raw_t * (3 - 2 * raw_t)
+    local eased = raw_t * raw_t * (3 - 2 * raw_t)
 
-    -- mars→alien なら t をそのまま、alien→mars なら反転
-    if target == 'mars' then t = 1.0 - t end
+    -- start_t から end_t へ補間（途中反転でも現在位置から滑らかに遷移）
+    local t = start_t + (end_t - start_t) * eased
 
+    state.current_t = t
     apply_interpolated_theme(window, t)
 
     step = step + 1
@@ -377,14 +384,22 @@ end
 
 -- ローカルpane上の前景プロセスが ssh の場合にテーマを切り替える
 -- 注: multiplexer pane や wezterm ssh ドメインでは検出不可
-wezterm.on('update-status', function(window, pane)
-  local proc = pane:get_foreground_process_name() or ''
-  if proc:find('ssh$') then
-    start_transition(window, 'alien')
-  else
-    start_transition(window, 'mars')
-  end
-end)
+-- wezterm.time が利用可能な場合のみフェードトランジションを有効化
+if wezterm.time then
+  wezterm.on('update-status', function(window, pane)
+    local proc = pane:get_foreground_process_name() or ''
+    -- ポーリングコスト軽減: プロセス名が変わっていない場合はスキップ
+    local state = get_win_state(window)
+    if proc == state.last_proc then return end
+    state.last_proc = proc
+
+    if proc:find('ssh$') then
+      start_transition(window, 'alien')
+    else
+      start_transition(window, 'mars')
+    end
+  end)
+end
 
 wezterm.on('bell', function(window, pane)
   window:toast_notification('Claude Code', 'Task completed', nil, 4000)

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -251,12 +251,19 @@ local theme_alien = {
 -- トランジション状態管理（ウィンドウ単位で管理し、複数ウィンドウの干渉を防ぐ）
 -- current_t: 現在の補間位置 (0.0=mars, 1.0=alien) を保持し、途中反転時のジャンプを防ぐ
 local transition_states = {}  -- window_id -> { current, generation, current_t, last_proc }
+local MAX_CACHED_WINDOWS = 20  -- stale entry 蓄積防止の上限
 local TRANSITION_STEPS = 8
 local TRANSITION_INTERVAL = 0.05  -- 各ステップ間隔（秒） → 合計 ~400ms
 
 local function get_win_state(window)
   local wid = tostring(window:window_id())
   if not transition_states[wid] then
+    -- stale entry が溜まりすぎたらテーブルをリセット
+    local count = 0
+    for _ in pairs(transition_states) do count = count + 1 end
+    if count >= MAX_CACHED_WINDOWS then
+      transition_states = {}
+    end
     transition_states[wid] = { current = 'mars', generation = 0, current_t = 0.0, last_proc = '' }
   end
   return transition_states[wid], wid
@@ -384,22 +391,30 @@ end
 
 -- ローカルpane上の前景プロセスが ssh の場合にテーマを切り替える
 -- 注: multiplexer pane や wezterm ssh ドメインでは検出不可
--- wezterm.time が利用可能な場合のみフェードトランジションを有効化
-if wezterm.time then
-  wezterm.on('update-status', function(window, pane)
-    local proc = pane:get_foreground_process_name() or ''
-    -- ポーリングコスト軽減: プロセス名が変わっていない場合はスキップ
-    local state = get_win_state(window)
-    if proc == state.last_proc then return end
-    state.last_proc = proc
+local has_time = (wezterm.time ~= nil)
 
-    if proc:find('ssh$') then
-      start_transition(window, 'alien')
-    else
-      start_transition(window, 'mars')
-    end
-  end)
-end
+wezterm.on('update-status', function(window, pane)
+  local proc = pane:get_foreground_process_name() or ''
+  -- ポーリングコスト軽減: プロセス名が変わっていない場合はスキップ
+  local state = get_win_state(window)
+  if proc == state.last_proc then return end
+  state.last_proc = proc
+
+  local is_ssh = (proc:find('ssh$') ~= nil)
+  local target = is_ssh and 'alien' or 'mars'
+
+  if has_time then
+    -- フェードトランジション付き
+    start_transition(window, target)
+  else
+    -- wezterm.time が利用不可の場合は即時切替（フォールバック）
+    if state.current == target then return end
+    state.current = target
+    local t = is_ssh and 1.0 or 0.0
+    state.current_t = t
+    apply_interpolated_theme(window, t)
+  end
+end)
 
 wezterm.on('bell', function(window, pane)
   window:toast_notification('Claude Code', 'Task completed', nil, 4000)

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -193,54 +193,175 @@ wezterm.on("format-tab-title", function(tab, tabs, panes, config, hover, max_wid
   }
 end)
 
--- SSH接続検出: 他の宇宙船に乗り込んだ演出
--- 現在の火星テーマから、冷たい青紫のエイリアン宇宙船風に切り替え
+-- === SSH接続検出: 他の宇宙船に乗り込んだ演出（フェードトランジション付き） ===
+
+local mars_img = os.getenv('HOME') .. '/work/letusfly85/dotfiles/mars.png'
+
+-- hex色をR,G,Bに分解
+local function hex2rgb(hex)
+  hex = hex:gsub('#', '')
+  return tonumber(hex:sub(1, 2), 16),
+         tonumber(hex:sub(3, 4), 16),
+         tonumber(hex:sub(5, 6), 16)
+end
+
+-- R,G,Bをhex色に変換
+local function rgb2hex(r, g, b)
+  return string.format('#%02x%02x%02x',
+    math.max(0, math.min(255, math.floor(r + 0.5))),
+    math.max(0, math.min(255, math.floor(g + 0.5))),
+    math.max(0, math.min(255, math.floor(b + 0.5))))
+end
+
+-- 2つのhex色を t (0.0〜1.0) で線形補間
+local function lerp_color(c1, c2, t)
+  local r1, g1, b1 = hex2rgb(c1)
+  local r2, g2, b2 = hex2rgb(c2)
+  return rgb2hex(
+    r1 + (r2 - r1) * t,
+    g1 + (g2 - g1) * t,
+    b1 + (b2 - b1) * t)
+end
+
+-- 数値を線形補間
+local function lerp(a, b, t) return a + (b - a) * t end
+
+-- 火星テーマ（通常）とエイリアン宇宙船テーマ（SSH）の定義
+local theme_mars = {
+  gradient = { '#000000', '#0A0A0A', '#1A0F0A', '#2D1B0E', '#4A2C1A' },
+  overlay  = { '#000814', '#000a14' },
+  img_opacity  = 0.55,
+  img_hue      = 1.0,
+  img_sat      = 1.0,
+  img_bright   = 1.0,
+  ovr_opacity  = 0.45,
+  scrollbar    = { 0, 255, 255, 0.35 },
+}
+local theme_alien = {
+  gradient = { '#000010', '#0A0A2E', '#0F1A3A', '#162050', '#1A1A4A' },
+  overlay  = { '#000020', '#0A0A3E' },
+  img_opacity  = 0.25,
+  img_hue      = 0.6,
+  img_sat      = 1.5,
+  img_bright   = 0.4,
+  ovr_opacity  = 0.55,
+  scrollbar    = { 100, 100, 255, 0.35 },
+}
+
+-- トランジション状態管理
+local transition_state = {
+  current = 'mars',   -- 現在のテーマ
+  step = 0,           -- 現在のステップ (0 = 完了)
+}
+local TRANSITION_STEPS = 8
+local TRANSITION_INTERVAL = 0.05  -- 各ステップ間隔（秒） → 合計 ~400ms
+
+-- t (0.0=mars, 1.0=alien) に基づいて中間テーマを適用
+local function apply_interpolated_theme(window, t)
+  if t <= 0.001 then
+    -- 完全に火星テーマ → オーバーライド解除で元のconfigに戻す
+    window:set_config_overrides({})
+    return
+  end
+
+  local from = theme_mars
+  local to = theme_alien
+
+  -- グラデーション色の補間
+  local grad = {}
+  for i = 1, 5 do
+    grad[i] = lerp_color(from.gradient[i], to.gradient[i], t)
+  end
+
+  -- オーバーレイ色の補間
+  local ovr = {}
+  for i = 1, 2 do
+    ovr[i] = lerp_color(from.overlay[i], to.overlay[i], t)
+  end
+
+  -- スクロールバー色の補間
+  local sb = string.format('rgba(%d, %d, %d, %.2f)',
+    math.floor(lerp(from.scrollbar[1], to.scrollbar[1], t)),
+    math.floor(lerp(from.scrollbar[2], to.scrollbar[2], t)),
+    math.floor(lerp(from.scrollbar[3], to.scrollbar[3], t)),
+    lerp(from.scrollbar[4], to.scrollbar[4], t))
+
+  window:set_config_overrides({
+    window_background_gradient = {
+      colors = grad,
+      orientation = 'Vertical',
+      blend = 'LinearRgb',
+    },
+    background = {
+      {
+        source = { File = mars_img },
+        attachment = 'Fixed',
+        opacity = lerp(from.img_opacity, to.img_opacity, t),
+        vertical_align = 'Middle',
+        horizontal_align = 'Center',
+        horizontal_offset = '0px',
+        repeat_x = 'NoRepeat',
+        repeat_y = 'NoRepeat',
+        height = '100%',
+        hsb = {
+          hue = lerp(from.img_hue, to.img_hue, t),
+          saturation = lerp(from.img_sat, to.img_sat, t),
+          brightness = lerp(from.img_bright, to.img_bright, t),
+        },
+      },
+      {
+        source = {
+          Gradient = {
+            colors = ovr,
+            orientation = { Linear = { angle = -50.0 } },
+          },
+        },
+        opacity = lerp(from.ovr_opacity, to.ovr_opacity, t),
+        width = '100%',
+        height = '100%',
+      },
+    },
+    colors = {
+      tab_bar = { inactive_tab_edge = 'none' },
+      scrollbar_thumb = sb,
+    },
+  })
+end
+
+-- フェードトランジションを開始
+local function start_transition(window, target)
+  if transition_state.current == target then return end
+  transition_state.current = target
+  transition_state.step = 1
+
+  local function step_fn()
+    local s = transition_state.step
+    if s > TRANSITION_STEPS then return end
+
+    -- イーズイン・アウト (smoothstep) で滑らかに
+    local raw_t = s / TRANSITION_STEPS
+    local t = raw_t * raw_t * (3 - 2 * raw_t)
+
+    -- mars→alien なら t をそのまま、alien→mars なら反転
+    if target == 'mars' then t = 1.0 - t end
+
+    apply_interpolated_theme(window, t)
+
+    transition_state.step = s + 1
+    if s < TRANSITION_STEPS then
+      wezterm.time.call_after(TRANSITION_INTERVAL, step_fn)
+    end
+  end
+
+  step_fn()
+end
+
 wezterm.on('update-status', function(window, pane)
   local proc = pane:get_foreground_process_name() or ''
   if proc:find('ssh$') then
-    window:set_config_overrides({
-      -- エイリアン宇宙船の背景グラデーション
-      window_background_gradient = {
-        colors = { '#000010', '#0A0A2E', '#0F1A3A', '#162050', '#1A1A4A' },
-        orientation = 'Vertical',
-        blend = 'LinearRgb',
-      },
-      -- 背景画像のオーバーレイを暗い青紫に
-      background = {
-        {
-          source = { File = os.getenv('HOME') .. '/work/letusfly85/dotfiles/mars.png' },
-          attachment = 'Fixed',
-          opacity = 0.25,
-          vertical_align = 'Middle',
-          horizontal_align = 'Center',
-          horizontal_offset = '0px',
-          repeat_x = 'NoRepeat',
-          repeat_y = 'NoRepeat',
-          height = '100%',
-          -- 青いティントで火星画像を異星感に
-          hsb = { hue = 0.6, saturation = 1.5, brightness = 0.4 },
-        },
-        {
-          source = {
-            Gradient = {
-              colors = { '#000020', '#0A0A3E' },
-              orientation = { Linear = { angle = -50.0 } },
-            },
-          },
-          opacity = 0.55,
-          width = '100%',
-          height = '100%',
-        },
-      },
-      colors = {
-        tab_bar = {
-          inactive_tab_edge = 'none',
-        },
-        scrollbar_thumb = 'rgba(100, 100, 255, 0.35)',
-      },
-    })
+    start_transition(window, 'alien')
   else
-    window:set_config_overrides({})
+    start_transition(window, 'mars')
   end
 end)
 

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -250,20 +250,14 @@ local theme_alien = {
 
 -- トランジション状態管理（ウィンドウ単位で管理し、複数ウィンドウの干渉を防ぐ）
 -- current_t: 現在の補間位置 (0.0=mars, 1.0=alien) を保持し、途中反転時のジャンプを防ぐ
+-- stale entry は wezterm プロセス再起動で自然消滅するため、明示的な掃除は行わない
 local transition_states = {}  -- window_id -> { current, generation, current_t, last_proc }
-local MAX_CACHED_WINDOWS = 20  -- stale entry 蓄積防止の上限
 local TRANSITION_STEPS = 8
 local TRANSITION_INTERVAL = 0.05  -- 各ステップ間隔（秒） → 合計 ~400ms
 
 local function get_win_state(window)
   local wid = tostring(window:window_id())
   if not transition_states[wid] then
-    -- stale entry が溜まりすぎたらテーブルをリセット
-    local count = 0
-    for _ in pairs(transition_states) do count = count + 1 end
-    if count >= MAX_CACHED_WINDOWS then
-      transition_states = {}
-    end
     transition_states[wid] = { current = 'mars', generation = 0, current_t = 0.0, last_proc = '' }
   end
   return transition_states[wid], wid
@@ -391,7 +385,7 @@ end
 
 -- ローカルpane上の前景プロセスが ssh の場合にテーマを切り替える
 -- 注: multiplexer pane や wezterm ssh ドメインでは検出不可
-local has_time = (wezterm.time ~= nil)
+local has_time = (type(wezterm.time) == 'table' and type(wezterm.time.call_after) == 'function')
 
 wezterm.on('update-status', function(window, pane)
   local proc = pane:get_foreground_process_name() or ''


### PR DESCRIPTION
## Summary
- SSH接続時にプロンプトとwezterm背景を「他の宇宙船に乗り込んだ」風に切り替え
- 通常の火星テーマ（暖かい赤茶系）→ SSH先はエイリアン宇宙船風（冷たい青紫〜シアン）に変化
- リモートホストにいることが一目でわかるように視覚的に強調

### zshrc の変更
- `$SSH_CONNECTION` でSSH接続を検出
- プロンプトの色相を青紫〜シアン（200-280）に固定（通常の時間帯グラデーションを上書き）
- ホスト名を `⟐ hostname` 形式でネオンシアン表示、プロンプト記号を `▸` に変更

### wezterm.lua の変更
- `update-status` イベントでフォアグラウンドプロセスが `ssh` かを検出
- SSH中は背景グラデーションを冷たい青紫系に切り替え
- 火星画像に青いティント（HSB調整）をかけて異星感を演出
- SSH切断後は自動的に元の火星テーマに復帰

## Test plan
- [ ] 通常時のプロンプト表示が変わっていないことを確認
- [ ] `ssh` でリモートホストに接続し、プロンプトにホスト名（⟐ hostname）が表示されることを確認
- [ ] SSH中にwezterm背景が青紫系に変化することを確認
- [ ] SSH切断後にweztermが元の火星テーマに戻ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)