### PR TITLE
fix(zsh): just 補完がディレクトリ移動・新規タブで無効になる問題を修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -4,8 +4,17 @@ export LANG=ja_JP.UTF-8
 export EDITOR=vim
 export SAVEHIST=100000
 
+# dotfiles ディレクトリの解決（$HOME/.zshrc のシンボリックリンク先から特定）
+# $0 はシェル起動方法で値が変わる（-zsh, zsh 等）ため、シンボリックリンクを直接解決する
+if [[ -L "$HOME/.zshrc" ]]; then
+  DOTFILES_DIR="${HOME}/.zshrc"
+  DOTFILES_DIR="${DOTFILES_DIR:A:h}"
+else
+  DOTFILES_DIR="${0:A:h}"
+fi
+
 # just (タスクランナー) 補完用 fpath（シンボリックリンク前提、compinit は zplug load 後に実行）
-[[ -d ${0:A:h}/zsh/completions ]] && fpath=(${0:A:h}/zsh/completions $fpath)
+[[ -d ${DOTFILES_DIR}/zsh/completions ]] && fpath=(${DOTFILES_DIR}/zsh/completions $fpath)
 
 # プロンプト設定（グラデーション付きディレクトリ + git ブランチ/ステータス）
 zmodload zsh/mathfunc
@@ -207,7 +216,7 @@ if [ -d $HOME/.pyenv ]; then
   export PATH="$HOME/.pyenv/shims:$PATH"
 fi
 
-export PATH=${0:A:h}/bin:$PATH
+export PATH=${DOTFILES_DIR}/bin:$PATH
 
 # direnv
 if command -v direnv &>/dev/null; then


### PR DESCRIPTION
## Summary
- `$0` はシェル起動方法で値が変わる（ログインシェルでは `-zsh`、`source` 時は `~/.zshrc`）ため、`${0:A:h}` で dotfiles ディレクトリを解決できず、`fpath` に `zsh/completions` が追加されないケースがあった
- `$HOME/.zshrc` のシンボリックリンクを直接解決する `DOTFILES_DIR` 変数を導入し、起動方法に依存しない安定した参照に変更
- `fpath`（just 補完）と `PATH`（dotfiles/bin）の両方を修正

## 原因
```
# 旧: $0 が -zsh の場合、${0:A:h} は dotfiles ディレクトリを指さない
[[ -d ${0:A:h}/zsh/completions ]] && fpath=(${0:A:h}/zsh/completions $fpath)
```

## 修正
```zsh
# ~/.zshrc のシンボリックリンク先を解決して dotfiles ディレクトリを特定
if [[ -L "$HOME/.zshrc" ]]; then
  DOTFILES_DIR="${HOME}/.zshrc"
  DOTFILES_DIR="${DOTFILES_DIR:A:h}"
else
  DOTFILES_DIR="${0:A:h}"
fi
```

## Test plan
- [ ] 新しい wezterm タブで `just <Tab>` が補完される
- [ ] `cd` で別ディレクトリ（justfile あり）に移動後、`just <Tab>` が補完される
- [ ] `source ~/.zshrc` なしで補完が動作する
- [ ] `echo $DOTFILES_DIR` が dotfiles リポジトリのパスを返す

🤖 Generated with [Claude Code](https://claude.com/claude-code)