### PR TITLE
feat: zoxide/fzf/eza/yazi/ripgrep/lazygit のインストールと zsh 統合を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -255,6 +255,16 @@ if [ -f $HOME/.cargo/bin/atuin ]; then
   eval "$(atuin init zsh)"
 fi
 
+# zoxide (smarter cd)
+if command -v zoxide &> /dev/null; then
+  eval "$(zoxide init zsh)"
+fi
+
+# fzf (fuzzy finder)
+if command -v fzf &> /dev/null; then
+  eval "$(fzf --zsh)"
+fi
+
 # パス設定
 [ -d "/usr/local/opt/libpq/bin" ] && export PATH="/usr/local/opt/libpq/bin:$PATH"
 [ -d "/opt/homebrew/opt/mysql-client/bin" ] && export PATH="/opt/homebrew/opt/mysql-client/bin:$PATH"

--- a/install-libraries.sh
+++ b/install-libraries.sh
@@ -34,3 +34,80 @@ brew install mecab-ipadic
 # Database CLI
 brew install mycli
 brew install pgcli
+
+# ---- Cross-platform (macOS / Ubuntu) tools ----
+# macOS は brew、Ubuntu/Debian は apt を利用する
+install_xplat() {
+    local name="$1"
+    local brew_pkg="$2"
+    local apt_pkg="$3"
+
+    case "$(uname -s)" in
+        Darwin)
+            brew install "$brew_pkg"
+            ;;
+        Linux)
+            if [ -f /etc/os-release ] && grep -qiE 'ubuntu|debian' /etc/os-release; then
+                sudo apt-get update
+                sudo apt-get install -y "$apt_pkg"
+            else
+                echo "Unsupported Linux distribution for $name" >&2
+            fi
+            ;;
+        *)
+            echo "Unsupported OS for $name install: $(uname -s)" >&2
+            ;;
+    esac
+}
+
+# zoxide (smarter cd)
+# https://github.com/ajeetdsouza/zoxide
+install_xplat zoxide zoxide zoxide
+
+# fzf (fuzzy finder)
+# https://github.com/junegunn/fzf
+install_xplat fzf fzf fzf
+
+# eza (modern ls)
+# https://github.com/eza-community/eza
+install_xplat eza eza eza
+
+# ripgrep (fast grep)
+# https://github.com/BurntSushi/ripgrep
+install_xplat ripgrep ripgrep ripgrep
+
+# lazygit (terminal UI for git)
+# https://github.com/jesseduffield/lazygit
+case "$(uname -s)" in
+    Darwin)
+        brew install lazygit
+        ;;
+    Linux)
+        if [ -f /etc/os-release ] && grep -qiE 'ubuntu|debian' /etc/os-release; then
+            # Ubuntu の apt には lazygit が無いため公式 tarball を使用
+            LAZYGIT_VERSION=$(curl -s "https://api.github.com/repos/jesseduffield/lazygit/releases/latest" | grep -Po '"tag_name": *"v\K[^"]*')
+            curl -Lo /tmp/lazygit.tar.gz "https://github.com/jesseduffield/lazygit/releases/latest/download/lazygit_${LAZYGIT_VERSION}_Linux_x86_64.tar.gz"
+            tar xf /tmp/lazygit.tar.gz -C /tmp lazygit
+            sudo install /tmp/lazygit /usr/local/bin
+            rm -f /tmp/lazygit /tmp/lazygit.tar.gz
+        fi
+        ;;
+esac
+
+# yazi (blazing fast terminal file manager)
+# https://github.com/sxyazi/yazi
+case "$(uname -s)" in
+    Darwin)
+        brew install yazi
+        ;;
+    Linux)
+        if [ -f /etc/os-release ] && grep -qiE 'ubuntu|debian' /etc/os-release; then
+            # Ubuntu の apt には yazi が無いため cargo でインストール
+            if command -v cargo &> /dev/null; then
+                cargo install --locked yazi-fm yazi-cli
+            else
+                echo "cargo が必要です。./install-crate.sh を先に実行するか rustup を導入してください" >&2
+            fi
+        fi
+        ;;
+esac


### PR DESCRIPTION
## Summary
- `install-libraries.sh` に macOS / Ubuntu (Debian) の両方に対応したモダン CLI ツール群のインストール処理を追加
- 追加ツール: zoxide / fzf / eza / yazi / ripgrep / lazygit
- `.zshrc` に zoxide と fzf のシェル統合 (`eval "$(zoxide init zsh)"` / `eval "$(fzf --zsh)"`) を追加

## Details
- `install_xplat` ヘルパーで brew と apt を OS 判定 (`uname -s` + `/etc/os-release`) により切り替え
- lazygit: Ubuntu の apt には含まれないため GitHub Release の tarball を取得する専用処理
- yazi: Ubuntu の apt には含まれないため cargo 経由でインストール

## Test plan
- [x] macOS 上で `brew install` が完了し、各ツールの `--version` が通ることを確認
- [x] `bash -n install-libraries.sh` で構文エラーがないことを確認
- [ ] Ubuntu 側は別途検証予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)