### PR TITLE
fix(install-libraries): yazi を yazi-build 経由でインストール

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # .claude/ - settings.local.json is excluded below
 .claude/settings.local.json
+
+# install-libraries.sh が配置する kustomize バイナリ
+/kustomize

--- a/install-libraries.sh
+++ b/install-libraries.sh
@@ -103,8 +103,11 @@ case "$(uname -s)" in
     Linux)
         if [ -f /etc/os-release ] && grep -qiE 'ubuntu|debian' /etc/os-release; then
             # Ubuntu の apt には yazi が無いため cargo でインストール
+            # yazi 26.x 以降は yazi-fm / yazi-cli を個別に install できず、
+            # メタクレート yazi-build 経由でまとめてビルドする必要がある。
+            # https://yazi-rs.github.io/docs/installation
             if command -v cargo &> /dev/null; then
-                cargo install --locked yazi-fm yazi-cli
+                cargo install --force yazi-build
             else
                 echo "cargo が必要です。./install-crate.sh を先に実行するか rustup を導入してください" >&2
             fi


### PR DESCRIPTION
## Summary
- yazi 26.x 以降の `yazi-fm` / `yazi-cli` は build.rs に「`cargo install --force yazi-build` で入れろ」というガードがあり、`cargo install --locked yazi-fm yazi-cli` だとビルドに失敗するため `cargo install --force yazi-build` に変更
- `--locked` は `core2 v0.4.0` が yanked のため警告が出るので外す
- `install-libraries.sh` の `# kustomize` セクションがリポジトリ直下に配置する `kustomize` バイナリを `.gitignore` に追加

参考エラー:
```
thread 'main' panicked at .../yazi-fm-26.1.22/build.rs:23:9:
Due to Cargo's limitations, the `yazi-fm` and `yazi-cli` crates on crates.io
must be built with `cargo install --force yazi-build`
```

## Test plan
- [ ] Ubuntu 環境で `./install-libraries.sh` を実行し、`yazi` / `ya` コマンドがインストールされること
- [ ] `kustomize` インストール後 `git status` に `kustomize` が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)