### PR TITLE
fix(zsh): ~/.fzf/bin を PATH 先頭に追加して `fzf --zsh` の互換性を確保

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -261,6 +261,7 @@ if command -v zoxide &> /dev/null; then
 fi
 
 # fzf (fuzzy finder)
+[ -d "$HOME/.fzf/bin" ] && export PATH="$HOME/.fzf/bin:$PATH"
 if command -v fzf &> /dev/null; then
   eval "$(fzf --zsh)"
 fi


### PR DESCRIPTION
## Summary
- SSH ログイン時に `unknown option: --zsh` が表示される問題を修正
- 原因: `.zshrc` の `eval "$(fzf --zsh)"` が apt 版 fzf 0.44.1 を呼び出していたため。`--zsh` は fzf v0.48.0 以降のオプション
- 対応: 公式インストーラで `~/.fzf/bin` に新しめの fzf（0.72.0）を配置済みなので、`.zshrc` で `~/.fzf/bin` を PATH 先頭に通して新版を優先させる

## Test plan
- [ ] `~/.fzf/bin` が存在するホスト（fzf 0.48.0+）で SSH ログインしてエラーが出ないこと
- [ ] `~/.fzf/bin` が無いホストでも従来動作（apt 版 fzf を使い、本件以外の挙動は変えない）を維持すること
- [ ] `command -v fzf` が `~/.fzf/bin/fzf` を返すこと
- [ ] `fzf --zsh` が正常に zsh 統合スクリプトを出力すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)