### PR TITLE
feat(zsh): scp の zsh Tab 補完を追加し `-i <key>` を効くようにする

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -185,6 +185,12 @@ if [[ ! -f "$HOME/.zcompdump" ]] || [[ -n "$HOME/.zcompdump"(#qN.mh+24) ]]; then
 else
   compinit -C
 fi
+
+# 自前補完の上書き（compinit 後に登録しないとシステム同梱版に負ける）
+# 例: /usr/share/zsh/*/functions/_ssh は `#compdef ssh slogin=ssh scp ...` を持つため、
+# dotfiles 側 _scp が fpath で先に来ていても compinit 処理順で _ssh に上書きされる。
+[[ -r ${DOTFILES_DIR}/zsh/completions/_scp ]] && compdef _scp scp
+
 # 補完メニューを矢印キー/Tabで選択可能にする（zplug load 後に配置し上書きされないようにする）
 zstyle ':completion:*' menu select
 

--- a/zsh/completions/_scp
+++ b/zsh/completions/_scp
@@ -1,0 +1,65 @@
+#compdef scp
+# 手書き補完: zsh 同梱の _scp (実体は /usr/share/zsh/*/functions/_ssh) は
+#   '-i' の候補を `_files -g "*(-.^AR)"` でフィルタしており、
+#   group/other に読み取り権限が残っている鍵 (chmod 忘れの 644 .pem 等) が
+#   候補から無言で除外され、`scp <src> -i <TAB>` で補完が効かないように見える。
+# このファイルは fpath 経由で読み込まれ、システム同梱版より優先される。
+# scp の新規オプションに追従する場合は OpenSSH の man scp(1) を参照。
+
+_scp() {
+  local curcontext="$curcontext" state line ret=1 suf
+  typeset -A opt_args
+
+  _arguments -C -s \
+    '-3[相手ホスト同士の中継をローカルで行う]' \
+    '(-6)-4[IPv4 のみを使用]' \
+    '(-4)-6[IPv6 のみを使用]' \
+    '-A[認証エージェント転送を有効化]' \
+    '-B[バッチモード (パスフレーズを尋ねない)]' \
+    '-C[圧縮を有効化]' \
+    '-c+[暗号方式を指定]:cipher:' \
+    '-D[sftp サーバを直接呼び出す]' \
+    '-F+[ssh_config を指定]:config file:_files' \
+    '*-i+[認証鍵ファイル]:identity file:->identity' \
+    '-J+[踏み台ホスト]:jump host:_user_at_host' \
+    '-l+[帯域制限 (Kbit/s)]:bandwidth:' \
+    '-O[従来 scp プロトコルを使用]' \
+    '*-o+[ssh オプション]:option:' \
+    '-P+[リモートポート]:port:' \
+    '-p[属性 (mtime/atime/mode) を保持]' \
+    '-q[静音モード]' \
+    '-R[Remote-to-remote コピーを直接行う]' \
+    '-r[再帰コピー]' \
+    '-S+[ssh プログラム]:program:_command_names -e' \
+    '-T[厳格ファイル名チェックを無効化]' \
+    '-v[詳細ログ]' \
+    '-X+[sftp プロトコルオプション]:sftp option:' \
+    '*:file:->files' && ret=0
+
+  case $state in
+    identity)
+      # ~/.ssh 配下の鍵候補を優先表示しつつ、任意のパスも辿れるようにする。
+      # *.pub / known_hosts / config / authorized_keys 等の付随ファイルは除外。
+      _alternative \
+        'keys:SSH key:_files -W ~/.ssh -g "^(*.pub|known_hosts*|config|authorized_keys|environment)(-.)"' \
+        'files:file:_files' && ret=0
+      ;;
+    files)
+      if compset -P 1 '[^./][^/]#:'; then
+        _remote_files -- ssh ${(kv)~opt_args[(I)-[FP1246]]/-P/-p} && ret=0
+      elif compset -P 1 '*@'; then
+        suf=( -S '' )
+        compset -S ':*' || suf=( -r: -S: )
+        _wanted hosts expl 'remote host name' _ssh_hosts $suf && ret=0
+      else
+        _alternative \
+          'files:: _files' \
+          'hosts:remote host name:_ssh_hosts -r: -S:' && ret=0
+      fi
+      ;;
+  esac
+
+  return ret
+}
+
+_scp "$@"

--- a/zsh/completions/_scp
+++ b/zsh/completions/_scp
@@ -4,47 +4,46 @@
 #   group/other に読み取り権限が残っている鍵 (chmod 忘れの 644 .pem 等) が
 #   候補から無言で除外され、`scp <src> -i <TAB>` で補完が効かないように見える。
 # このファイルは fpath 経由で読み込まれ、システム同梱版より優先される。
-# scp の新規オプションに追従する場合は OpenSSH の man scp(1) を参照。
+# 構造は同梱の _ssh の scp 分岐をベースに、'-i' のみ素の _files に差し替えた。
 
 _scp() {
-  local curcontext="$curcontext" state line ret=1 suf
+  local curcontext="$curcontext" state line expl suf ret=1
   typeset -A opt_args
 
+  local -a common common_transfer
+  common=(
+    '(-6)-4[force ssh to use IPv4 addresses only]'
+    '(-4)-6[force ssh to use IPv6 addresses only]'
+    '-A[enable forwarding of the authentication agent connection]'
+    '-C[compress data]'
+    '-c+[select encryption cipher]:encryption cipher'
+    '-F+[specify alternate config file]:config file:_files'
+    '*-i+[select identity file]:SSH identity file:_files'
+    '*-o+[specify extra options]:option string'
+  )
+  common_transfer=(
+    '-J+[connect via a jump host]:jump host:_user_at_host'
+    '-l+[limit used bandwidth]:bandwidth (Kbit/s)'
+    '-P+[specify port on remote host]:port number on remote host'
+    '-p[preserve modification times, access times and modes]'
+    '-q[disable progress meter and warnings]'
+    '-r[recursively copy directories (follows symbolic links)]'
+    '-S+[specify ssh program]:path to ssh:_command_names -e'
+    '-v[verbose mode]'
+  )
+
   _arguments -C -s \
-    '-3[相手ホスト同士の中継をローカルで行う]' \
-    '(-6)-4[IPv4 のみを使用]' \
-    '(-4)-6[IPv6 のみを使用]' \
-    '-A[認証エージェント転送を有効化]' \
-    '-B[バッチモード (パスフレーズを尋ねない)]' \
-    '-C[圧縮を有効化]' \
-    '-c+[暗号方式を指定]:cipher:' \
-    '-D[sftp サーバを直接呼び出す]' \
-    '-F+[ssh_config を指定]:config file:_files' \
-    '*-i+[認証鍵ファイル]:identity file:->identity' \
-    '-J+[踏み台ホスト]:jump host:_user_at_host' \
-    '-l+[帯域制限 (Kbit/s)]:bandwidth:' \
-    '-O[従来 scp プロトコルを使用]' \
-    '*-o+[ssh オプション]:option:' \
-    '-P+[リモートポート]:port:' \
-    '-p[属性 (mtime/atime/mode) を保持]' \
-    '-q[静音モード]' \
-    '-R[Remote-to-remote コピーを直接行う]' \
-    '-r[再帰コピー]' \
-    '-S+[ssh プログラム]:program:_command_names -e' \
-    '-T[厳格ファイル名チェックを無効化]' \
-    '-v[詳細ログ]' \
-    '-X+[sftp プロトコルオプション]:sftp option:' \
-    '*:file:->files' && ret=0
+    '-3[copy through local host, not directly between the remote hosts]' \
+    '-B[batch mode (do not ask for passphrases)]' \
+    '-D[invoke sftp server directly]' \
+    '-O[use the legacy scp protocol]' \
+    '-R[copy between two remote hosts is performed by the remote host]' \
+    '-T[disable strict filename checking]' \
+    '-X+[specify sftp protocol option]:sftp option' \
+    '*:file:->file' "$common[@]" "$common_transfer[@]" && ret=0
 
   case $state in
-    identity)
-      # ~/.ssh 配下の鍵候補を優先表示しつつ、任意のパスも辿れるようにする。
-      # *.pub / known_hosts / config / authorized_keys 等の付随ファイルは除外。
-      _alternative \
-        'keys:SSH key:_files -W ~/.ssh -g "^(*.pub|known_hosts*|config|authorized_keys|environment)(-.)"' \
-        'files:file:_files' && ret=0
-      ;;
-    files)
+    file)
       if compset -P 1 '[^./][^/]#:'; then
         _remote_files -- ssh ${(kv)~opt_args[(I)-[FP1246]]/-P/-p} && ret=0
       elif compset -P 1 '*@'; then


### PR DESCRIPTION
## 背景

`scp <src> -i <key_path> <user>@<host>:<dst>` のように打ったとき、`<key_path>` で Tab 補完が効かない (候補が出ない) ケースがある。

## 原因

zsh 同梱の `_scp` (実体は `/usr/share/zsh/*/functions/_ssh` 内) の `-i` 補完定義は次のようになっている:

```
'*-i+[select identity file]:SSH identity file:_files -g "*(-.^AR)"'
```

末尾の glob 修飾子 `(-.^AR)` は「**group/other に読み取り権限がない 通常ファイル**」のみを通すフィルタ。AWS から落としてきた `.pem` を `chmod 400` し忘れて `644` のままだと、この条件で**候補から無言で除外**され、補完が効かないように見える。

## 変更内容

`just` のときと同じ要領で `zsh/completions/_scp` を新規追加。`.zshrc:16-17` で既に `zsh/completions` は `fpath` に追加済みなので、ファイルを置くだけでシステム同梱版より優先される。

- `-i` の候補を素の `_files` に差し替え (パーミッションでフィルタしない)
- `~/.ssh` 配下の鍵を `_alternative` で優先表示しつつ、任意のパスも辿れるよう fallback あり
- `*.pub` / `known_hosts*` / `config` / `authorized_keys` / `environment` は鍵候補から除外
- それ以外のオプション・位置引数 (`user@host:path` の補完など) は同梱版と同等の挙動を維持

## 動作確認

- `zsh -n zsh/completions/_scp` で構文 OK
- `fpath` を通した状態で `which _scp` がリポジトリ側の `_scp` を返すことを確認
- 実際に新しい zsh セッションで `scp foo.txt -i ~/.ssh/<TAB>` を試してください (chmod が緩い鍵でも候補に出るはず)

## 関連

- `just` 補完追加 PR: #50, #51