### PR TITLE
feat(aliases): q/cy ショートカットと cat の zenburn テーマを追加

### DIFF
--- a/base_aliases
+++ b/base_aliases
@@ -1,4 +1,8 @@
 # utils
-alias cat='bat --paging=never'
+alias cat='bat --paging=never --theme=zenburn'
 alias ll='exa -laFb -s time'
 alias tf='terraform'
+
+# shortcuts
+alias q='exit'
+alias cy='claude --dangerously-skip-permissions'


### PR DESCRIPTION
## 概要

エイリアスを2つ追加し、`cat` に zenburn テーマを取り込みます。

## 変更内容

- `q='exit'` — ターミナルセッションを閉じるショートカット
- `cy='claude --dangerously-skip-permissions'` — 既存コマンドと衝突しない2文字（"claude yolo" の語呂）
- `cat='bat --paging=never --theme=zenburn'` — `~/.aliases` 側にのみ存在した zenburn テーマ指定をリポジトリへ取り込み

あわせて `~/.aliases` を `base_aliases` へのシンボリックリンク化済み（未使用の `shogun` エイリアスは破棄）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)