### PR TITLE
feat(wezterm): タブを左右に並べ替えるキーバインドを追加（端で回り込み）

### DIFF
--- a/wezterm.lua
+++ b/wezterm.lua
@@ -16,6 +16,9 @@ end
 local default_cwd = wezterm.home_dir
 local work_dir = wezterm.home_dir .. '/work'
 
+-- タブ移動のモディファイア: macOS は Option を IME に譲るため CMD+CTRL を使う
+local tab_move_mods = wezterm.target_triple:find('apple') and 'CMD|CTRL' or 'CTRL|SHIFT'
+
 config = {
   default_prog = { zsh_path, '-l' },
   default_cwd = work_dir,
@@ -134,6 +137,23 @@ config = {
   max_fps = 120,
   scrollback_lines = 10000,
   enable_scroll_bar = true,
+
+  -- タブの並べ替え
+  -- WezTerm はタブバー上でのドラッグ&ドロップによる並べ替えに未対応のため
+  -- (https://github.com/wezterm/wezterm/issues/549)、キーバインドで代替する。
+  -- macOS: CMD+CTRL+←/→ 、それ以外: CTRL+SHIFT+←/→ でアクティブなタブを左右に移動
+  keys = {
+    {
+      key = 'LeftArrow',
+      mods = tab_move_mods,
+      action = act.MoveTabRelative(-1),
+    },
+    {
+      key = 'RightArrow',
+      mods = tab_move_mods,
+      action = act.MoveTabRelative(1),
+    },
+  },
 
   -- マウスホイールスクロールを固定行数にしてガクガクを防止
   mouse_bindings = {

--- a/wezterm.lua
+++ b/wezterm.lua
@@ -19,6 +19,30 @@ local work_dir = wezterm.home_dir .. '/work'
 -- タブ移動のモディファイア: macOS は Option を IME に譲るため CMD+CTRL を使う
 local tab_move_mods = wezterm.target_triple:find('apple') and 'CMD|CTRL' or 'CTRL|SHIFT'
 
+-- アクティブなタブを左右に移動する（端まで来たら反対側へ回り込む）
+-- 標準の MoveTabRelative は端で止まる (clamp) 実装なので、
+-- MoveTab に 0 始まりの絶対インデックスを渡して自前でラップさせる
+local function move_tab_wrapping(delta)
+  return wezterm.action_callback(function(window, pane)
+    local tabs = window:mux_window():tabs_with_info()
+    local count = #tabs
+    if count < 2 then
+      return
+    end
+
+    local active = 0
+    for _, item in ipairs(tabs) do
+      if item.is_active then
+        active = item.index -- index は 0 始まり
+        break
+      end
+    end
+
+    -- Lua の % は床剰余なので負数でも正しく回り込む ((-1) % 3 == 2)
+    window:perform_action(act.MoveTab((active + delta) % count), pane)
+  end)
+end
+
 config = {
   default_prog = { zsh_path, '-l' },
   default_cwd = work_dir,
@@ -141,17 +165,18 @@ config = {
   -- タブの並べ替え
   -- WezTerm はタブバー上でのドラッグ&ドロップによる並べ替えに未対応のため
   -- (https://github.com/wezterm/wezterm/issues/549)、キーバインドで代替する。
-  -- macOS: CMD+CTRL+←/→ 、それ以外: CTRL+SHIFT+←/→ でアクティブなタブを左右に移動
+  -- macOS: CMD+CTRL+←/→ 、それ以外: CTRL+SHIFT+←/→ でアクティブなタブを左右に移動。
+  -- 右端で更に右へ送ると左端へ、左端で更に左へ送ると右端へ回り込む。
   keys = {
     {
       key = 'LeftArrow',
       mods = tab_move_mods,
-      action = act.MoveTabRelative(-1),
+      action = move_tab_wrapping(-1),
     },
     {
       key = 'RightArrow',
       mods = tab_move_mods,
-      action = act.MoveTabRelative(1),
+      action = move_tab_wrapping(1),
     },
   },
 


### PR DESCRIPTION
## 背景

「WezTerm のタブをドラッグ&ドロップで左右に並べ替えたい」という要望から。

調べたところ **WezTerm はタブバー上でのドラッグ&ドロップによる並べ替えに未対応**でした。
機能リクエストの [wezterm/wezterm#549](https://github.com/wezterm/wezterm/issues/549) が 2021 年から open のままです。

代替としてキーバインドで並べ替えられるようにします。

## 変更内容

`wezterm.lua` に `keys` 設定を追加（これまで config 内に `keys` 定義自体が無かった）。

| OS | キー | 動作 |
| --- | --- | --- |
| macOS | `CMD+CTRL+←` / `CMD+CTRL+→` | アクティブなタブを1つ左/右へ移動 |
| その他 | `CTRL+SHIFT+←` / `CTRL+SHIFT+→` | 同上 |

**端まで来たら反対側へ回り込みます**（右端のタブを更に右へ送ると左端へ、左端で更に左へ送ると右端へ）。

macOS で Option (ALT) を避けているのは、`use_ime = true` のため IME に譲る意図です。

## なぜ MoveTabRelative をそのまま使わないか

標準の `MoveTabRelative` は端で**止まる (clamp)** 実装で、回り込みません:

```rust
// wezterm-gui/src/termwindow/mod.rs  fn move_tab_relative
let tab = if tab < 0 { 0usize }
          else if tab >= max as isize { max - 1 }   // ← 端で止まる
          else { tab as usize };
```

そのため `MoveTab`（0 始まりの絶対インデックスを取る）に床剰余で求めた位置を渡す
`action_callback` を自前で用意しています。Lua の `%` は床剰余なので、
負の delta でも `(-1) % 3 == 2` と正しく回り込みます。

## 補足

WezTerm 標準の `CTRL+SHIFT+PageUp` / `CTRL+SHIFT+PageDown` にもタブ移動が
デフォルトで割り当たっています（こちらは clamp のまま。今回の変更で潰していません）。
Mac のキーボードでは `fn+↑/↓` になり押しにくいので、矢印キー版を追加する形にしています。

## 動作確認

設定がエラーなくロードされ、キーが登録されることを確認:

```console
$ wezterm --config-file "$PWD/wezterm.lua" show-keys
	CTRL | SUPER         LeftArrow          ->   EmitEvent("user-defined-0")
	CTRL | SUPER         RightArrow         ->   EmitEvent("user-defined-1")
```

（`action_callback` は `EmitEvent(...)` として登録されます）

回り込みのインデックス計算を lua で単体検証:

```console
OK  active=2 delta=+1 count=3 -> 0   # 右端 -> 左端
OK  active=0 delta=-1 count=3 -> 2   # 左端 -> 右端
OK  active=4 delta=+1 count=5 -> 0
... ALL PASS
```

実際の GUI 上でのタブ移動は未検証のため、マージ後に手元で確認をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)